### PR TITLE
Add possibilty to configure a "per-tenant" label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p lib64 && cp /lib64/ld-linux-x86-64.so.2 lib64/
 
 RUN mkdir /data && cp /build/deploy/cortex-tenant.yml /data/cortex-tenant.yml
 
-FROM scratch
+FROM alpine
 
 COPY --chown=65534:0 --from=builder /dist /
 
@@ -32,6 +32,5 @@ USER 65534
 
 WORKDIR /data
 
-COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/cortex-tenant"]
 CMD ["-config", "/data/cortex-tenant.yml"]

--- a/config.go
+++ b/config.go
@@ -22,11 +22,12 @@ type config struct {
 	Metadata        bool
 
 	Tenant struct {
-		Label       string
-		LabelRemove bool `yaml:"label_remove"`
-		Header      string
-		Default     string
-		AcceptAll   bool `yaml:"accept_all"`
+		Label          string
+		LabelRemove    bool   `yaml:"label_remove"`
+		PerTenantLabel string `yaml:"per_tenant_label"`
+		Header         string
+		Default        string
+		AcceptAll      bool `yaml:"accept_all"`
 	}
 
 	pipeIn  *fhu.InmemoryListener

--- a/processor.go
+++ b/processor.go
@@ -266,11 +266,11 @@ func (p *processor) processTimeseries(ts *prompb.TimeSeries) (tenant string, err
 	for i, l := range ts.Labels {
 		if l.Name == p.cfg.Tenant.Label {
 			tenant, idx = l.Value, i
-			break
+			continue
 		}
 		if l.Name == p.cfg.Tenant.PerTenantLabel {
 			perTenantLabel = l.Value
-			break
+			continue
 		}
 	}
 

--- a/processor.go
+++ b/processor.go
@@ -33,6 +33,13 @@ type processor struct {
 	shuttingDown uint32
 
 	logger.Logger
+
+	tenantRegistry sync.Map
+}
+
+type tenantRegistryEntry struct {
+	LastAccess time.Time
+	Tenant     string
 }
 
 func newProcessor(c config) *processor {
@@ -255,19 +262,35 @@ func (p *processor) dispatch(clientIP net.Addr, reqID uuid.UUID, m map[string]*p
 
 func (p *processor) processTimeseries(ts *prompb.TimeSeries) (tenant string, err error) {
 	idx := 0
+	perTenantLabel := ""
 	for i, l := range ts.Labels {
 		if l.Name == p.cfg.Tenant.Label {
 			tenant, idx = l.Value, i
 			break
 		}
+		if l.Name == p.cfg.Tenant.PerTenantLabel {
+			perTenantLabel = l.Value
+			break
+		}
 	}
 
 	if tenant == "" {
+		if perTenantLabel != "" {
+			// tenant unknown but perTenantLabel known => check registry
+			tenant, ok := p.knownTenant(perTenantLabel)
+			if ok {
+				return tenant, nil
+			}
+			// else: go on with original default-tenant logic
+		}
 		if p.cfg.Tenant.Default == "" {
 			return "", fmt.Errorf("label '%s' not found", p.cfg.Tenant.Label)
 		}
 
 		return p.cfg.Tenant.Default, nil
+	} else if perTenantLabel != "" {
+		// tenant and perTenantLabel labels set => register
+		p.registerTenant(perTenantLabel, tenant)
 	}
 
 	if p.cfg.Tenant.LabelRemove {
@@ -322,4 +345,51 @@ func (p *processor) close() (err error) {
 	time.Sleep(p.cfg.TimeoutShutdown)
 	// Shutdown
 	return p.srv.Shutdown()
+}
+
+// Some cadvisor metrics don't contain the k8s pod labels (for example metrics
+// for other processes running under the same pods). We don't really need the
+// labels, but we *do* need the tenant label. So here we save to a map of
+// tenant to some other label (pod name, or whatever is unique per tenant),
+// so we can add the tenant label for containers that don't have them.
+
+func (p *processor) knownTenant(key string) (string, bool) {
+	value, ok := p.tenantRegistry.Load(key)
+	if !ok {
+		return "", false
+	}
+	entry, ok := value.(*tenantRegistryEntry)
+	if !ok {
+		// key is set, so this should always be an entry,
+		// and we should never get here
+		return "", false
+	}
+	// update access time
+	entry.LastAccess = time.Now()
+	p.tenantRegistry.Store(key, entry)
+	return entry.Tenant, true
+}
+
+func (p *processor) registerTenant(key, tenant string) {
+	entry := tenantRegistryEntry{
+		LastAccess: time.Now(),
+		Tenant:     tenant,
+	}
+	p.tenantRegistry.Store(key, &entry)
+	// expire old entries in the background, so this map doesn't grow forever
+	cutoff := time.Now().Add(-1 * time.Hour)
+	go p.tenantRegistry.Range(func(key, value interface{}) bool {
+		stringKey, ok := key.(string)
+		if !ok {
+			return true // ignoring, go on (should never happen, all keys are strings)
+		}
+		entry, ok := value.(*tenantRegistryEntry)
+		if !ok {
+			return true // should also never happen, all entries are *tenantRegistryEntry
+		}
+		if entry.LastAccess.Before(cutoff) {
+			p.tenantRegistry.Delete(stringKey)
+		}
+		return true
+	})
 }


### PR DESCRIPTION
Metrics with that label may *sometimes* have a tenant label, and sometimes not. Once we've seen it with a tenant, we remember that association, and use that tenant for all other metrics with the same "per-tenant" label.